### PR TITLE
Added some features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *py?
 *.egg-info
+*.swp
 dist/
 .installed.cfg
 .mr.developer.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
-python: 2.7
+python: 
+  - 2.7
+  - 3.2
+  - 3.3
+  - 3.4
+  - pypy
 install: make travis
 script: bin/test
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,16 @@ buildout: bin/buildout
 test:
 	@bin/test --with-coverage --cover-package=cosent.buildtools --cover-erase
 
-bin/buildout: bin/python2.7
-	@wget http://downloads.buildout.org/1/bootstrap.py
-	@bin/python2.7 bootstrap.py
+bin/buildout: bin/python
+	@wget http://downloads.buildout.org/2/bootstrap.py
+	@bin/python bootstrap.py
 	@rm bootstrap.*
 
-bin/python2.7:
-	@virtualenv --clear -p python2.7 --distribute .
+bin/python:
+	@virtualenv --clear -p python .
 
 travis:
-	wget http://downloads.buildout.org/1/bootstrap.py
+	wget http://downloads.buildout.org/2/bootstrap.py
 	python bootstrap.py
 	rm bootstrap.*
 	bin/buildout

--- a/README.rst
+++ b/README.rst
@@ -57,13 +57,15 @@ buildtool
 
 *buildtool cook* prepares your eggs for release::
 
-  buildtool [-n] [-f] [-s] [-c] cook
+  buildtool [-n] [-f] [-s] [-c] [-e] cook
     Bump version, commit and tag all eggs that have unreleased commits.
 
     [-n]          dry run, no changes
     [-f]          force a new release, even if no changes
     [-s]          skip sanity check, accept uncommitted changes
     [-c]          create RC (0.1->0.2rc1) instead of final version (0.1->0.2)
+
+    [-e eggs]     exclude eggs from buildtool (comma seperated list)
 
 *buildtool dist* releases all eggs and the buildout itself in one go::
 
@@ -81,6 +83,7 @@ buildtool
     <-v versions> path to buildout versions.txt file
     <-d dist>     pypirc dist location to use for uploading eggs
     [-b name]     name of current buildout, defaults to dirname
+    [-e eggs]     exclude eggs from buildtool (comma seperated list)
 
 *buildtool git* runs a git command on all eggs and on the buildout::
 
@@ -118,7 +121,8 @@ If you modify your buildout like this::
     initialization = defaults = {
       'versions-file':'versions.txt',
       'dist-location':'pypi',
-      'build-name': 'cosent.buildtools'}
+      'build-name': 'cosent.buildtools',
+      'exclude': 'egg1,egg2,egg3'}
     arguments = defaults
 
 Where of course you'll need to supply your own dist-location, for example 'your.server.net:/var/www/packages/local' and set build-name to your own project name. You can use any dist-location jarn.mkrelease accepts, including aliases defined in your .pypirc.

--- a/cosent/buildtools/compat.py
+++ b/cosent/buildtools/compat.py
@@ -1,0 +1,12 @@
+import sys
+
+is_PY2 = sys.version_info < (3, 0)
+
+if is_PY2:
+    from ConfigParser import ConfigParser
+    b = lambda x: x
+    s = lambda x: x
+else:
+    from configparser import ConfigParser
+    b = lambda x: bytes(x, "utf-8")
+    s = lambda x: str(x, "utf-8")

--- a/cosent/buildtools/tests/test_buildtool.py
+++ b/cosent/buildtools/tests/test_buildtool.py
@@ -10,6 +10,8 @@ dummypath = "%s/src/cosent.dummypackage" % os.getcwd()
 
 
 class TestGit(unittest.TestCase):
+    stash = False
+    stashed = False
 
     def setUp(self):
         # reset src/cosent.dummypackage
@@ -20,16 +22,17 @@ class TestGit(unittest.TestCase):
                                stdout=subprocess.PIPE)
         stdout, stderr = cmd.communicate()
         # stash cosent.buildtools
-        cmd = subprocess.Popen("git stash",
-                               shell=True,
-                               cwd=os.getcwd(),
-                               stdin=subprocess.PIPE,
-                               stdout=subprocess.PIPE)
-        stdout, stderr = cmd.communicate()
-        if 'HEAD is now at' in stdout:
-            self.stashed = True
-        else:
-            self.stashed = False
+        if self.stash:
+            cmd = subprocess.Popen("git stash",
+                                   shell=True,
+                                   cwd=os.getcwd(),
+                                   stdin=subprocess.PIPE,
+                                   stdout=subprocess.PIPE)
+            stdout, stderr = cmd.communicate()
+            if 'HEAD is now at' in stdout:
+                self.stashed = True
+            else:
+                self.stashed = False
 
     def tearDown(self):
         if not self.stashed:
@@ -53,7 +56,7 @@ class TestGit(unittest.TestCase):
 
     def test_all_clean_true(self):
         self.assertTrue(
-            bt.is_all_clean(),
+            bt.is_all_clean(dummypath),
             "\n%s:\n%s\n\n%s:\n%s" % (
                 dummypath, bt.git_status(dummypath),
                 bt.BASEDIR, bt.git_status(bt.BASEDIR)))

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.2.1'
+version = '1.2.2rc1'
 
 # http://pypi.python.org/pypi?%3Aaction=list_classifiers
 setup(name='cosent.buildtools',


### PR DESCRIPTION
I added python3 support and excludes to prevent from releasing eggs that are third party but in sources section.

Features we could also add:
- PEP 404 versioning (minor, major, ... )
- More tests
- Better error handling, messages if setup.py or version.txt is different ...
- Optional creating of a new source.cfg file for created tags (support source releases) 
